### PR TITLE
[ENG-1142] - Add database and encryption key on maestro deployment

### DIFF
--- a/charts/orb/Chart.yaml
+++ b/charts/orb/Chart.yaml
@@ -10,7 +10,7 @@ name: orb
 description: Orb Observability Platform
 icon: https://avatars1.githubusercontent.com/u/13207490
 type: application
-version: 1.0.47
+version: 1.0.48
 appVersion: "0.26.0"
 home: https://getorb.io
 sources:
@@ -62,6 +62,11 @@ dependencies:
     repository: ""
     alias: postgresql-keto
     condition: postgresql-keto.enabled
+  - name: postgresql
+    version: "10.9.1"
+    repository: ""
+    alias: postgresql-maestro
+    condition: postgresql-maestro.enabled
   - name: redis
     version: "14.8.8"
     repository: ""

--- a/charts/orb/templates/maestro-deployment.yaml
+++ b/charts/orb/templates/maestro-deployment.yaml
@@ -21,6 +21,44 @@ spec:
       serviceAccountName: k8s-maestro-role
       containers:
         - env:
+            - name: ORB_SINKS_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: orb-sinks-encryption-key
+                  key: key
+                  optional: false
+            - name: ORB_MAESTRO_DB
+              value: {{ index .Values "postgresql-maestro" "postgresqlDatabase" }}
+            - name: ORB_MAESTRO_DB_HOST
+            {{ if not .Values.maestro.dbHost }}
+              value: {{ .Release.Name }}-postgresql-maestro
+            {{ else }}
+              value: {{ .Values.maestro.dbHost }}
+            {{ end }}
+            - name: ORB_MAESTRO_DB_PASS
+            {{ if not .Values.maestro.secretPass }}
+              value: {{ index .Values "postgresql-maestro" "postgresqlPassword" }}
+            {{ else }}
+              valueFrom :
+                secretKeyRef :
+                  name : orb-maestro-credentials
+                  key : password
+                  optional : false
+            {{ end }}
+            - name: ORB_MAESTRO_DB_PORT
+              value: "{{ .Values.maestro.dbPort }}"
+            - name: ORB_MAESTRO_DB_SSL_MODE
+              value: "{{ .Values.maestro.dbSSL }}"
+            - name: ORB_MAESTRO_DB_USER
+            {{ if not .Values.maestro.secretPass }}
+              value: {{ index .Values "postgresql-maestro" "postgresqlUsername" }}
+            {{ else }}
+              valueFrom :
+                secretKeyRef :
+                  name : orb-maestro-credentials
+                  key : username
+                  optional : false
+            {{ end }}
             - name: ORB_SINKS_GRPC_URL
               value:
                 {{ .Release.Name }}-envoy:{{ .Values.sinks.grpcPort }}

--- a/charts/orb/values.yaml
+++ b/charts/orb/values.yaml
@@ -292,6 +292,21 @@ postgresql-keto:
     helm.sh/hook: "pre-install, pre-upgrade"
     helm.sh/hook-weight: "-1"
 
+postgresql-maestro:
+  enabled: true # dependency install, disable if you want to use external services
+  name: postgresql-maestro
+  postgresqlUsername: postgres
+  postgresqlPassword: orb
+  postgresqlDatabase: maestro
+  resources:
+    requests:
+      cpu: 25m
+  persistence:
+    size: 1Gi
+  commonAnnotations:
+    helm.sh/hook: "pre-install, pre-upgrade"
+    helm.sh/hook-weight: "-1"
+
 redis-streams:
   enabled: true # dependency install, disable if you want to use external services
   volumePermissions:
@@ -384,6 +399,9 @@ zookeeper:
   allowAnonymousLogin: true
 
 maestro:
+  dbPort: 5432
+  dbHost: "" # Set this field with host if you want to point to external database such as RDS
+  dbSSL: "disable"
   redisESPort: 6379
   redisESHost: "" # Set this field with host if you want to point to external database such as Elasticache
   redisCachePort: 6379


### PR DESCRIPTION
In order to manage otelcollectors deployment we need to have a postgres database on maestro deployment. The sensitive informations will use sinks encryption key for it.