### PR TITLE
[ENG-1143] - (feat) add ci on orb-helm repository to publish release automatically

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -7,10 +7,9 @@ jobs:
   chart-release:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    steps:       
-      - uses: actions/setup-go@v4
-        with:
-          go-version: '1.20.0'
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3
 
       - name: install chart release
         run: |

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -31,5 +31,5 @@ jobs:
         if: ${{ steps.checkTag.outputs.exists == 'true' }}
         run: |
               echo "ERROR - version already released: '${{ env.VERSION }}'"
-              echo "Please choose a version number that never was launched"
+              echo "Please choose a helm chart version number that never was launched on Chart.yaml"
               exit 1          

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -12,6 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: check chart release
+        shell: bash
         run: |
           input="charts/orb/Chart.yaml"
           while IFS= read -r -uN line

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -19,5 +19,8 @@ jobs:
           do
             if [[ $line =~ (^version: ([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)$) ]]; then
               echo "match: '${BASH_REMATCH[2]}'"
+              # check if latest release tag is same version
+              
+              exit 1
             fi
           done <"$file"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -31,6 +31,6 @@ jobs:
         if: ${{ steps.checkTag.outputs.exists == 'true' }}
         run: |
               # check if any release tag is same version
-              echo "ERROR - version already released: '${BASH_REMATCH[2]}'"
+              echo "ERROR - version already released: '${{ env.VERSION }}'"
               echo "Please choose a version number that never was launched"
               exit 1          

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -17,10 +17,10 @@ jobs:
           file="charts/orb/Chart.yaml"
           while IFS= read -r line
           do
-            if [[ $line =~ (^version: ([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)$) ]]; then
-              echo "match: '${BASH_REMATCH[2]}'"
+            if [[ $line =~ (^version: ([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)$) ]]; then              
               # check if latest release tag is same version
-              
+
+              echo "ERROR - version already released: '${BASH_REMATCH[2]}'"
               exit 1
             fi
           done <"$file"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -15,7 +15,7 @@ jobs:
         run: |
           cd charts/orb/
           str=$(<Chart.yaml)
-          if [[ $str =~ (^version: ([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)$) ]]; then
+          if [[ $str =~ (^\s+version: ([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)$) ]]; then
             echo "match: '${BASH_REMATCH[2]}'"
           else
             echo "no match found"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,7 +18,7 @@ jobs:
           while IFS= read -r line
           do
             if [[ $line =~ (^version: ([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)$) ]]; then              
-              # check if latest release tag is same version
+              # check if any release tag is same version
 
               echo "ERROR - version already released: '${BASH_REMATCH[2]}'"
               echo "Please choose a version number that never was launched"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -17,8 +17,7 @@ jobs:
           file="charts/orb/Chart.yaml"
           while IFS= read -r line
           do
-            if [[ $line =~ (^\s+version: ([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)$) ]]; then
+            if [[ $line =~ (^version: ([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)$) ]]; then
               echo "match: '${BASH_REMATCH[2]}'"
             fi
-            echo "$line"
           done <"$file"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -21,6 +21,7 @@ jobs:
               # check if latest release tag is same version
 
               echo "ERROR - version already released: '${BASH_REMATCH[2]}'"
+              echo "Please choose a version number that never was launched"
               exit 1
             fi
           done <"$file"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -2,8 +2,6 @@ name: Chart Version Check
 
 on:
   pull_request:
-    branches:
-      - main
 
 jobs:
   chart-release:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -13,9 +13,12 @@ jobs:
 
       - name: check chart release
         run: |
-          str=$(cat charts/orb/Chart.yaml)
-          if [[ $str =~ (^\s+version: ([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)$) ]]; then
-            echo "match: '${BASH_REMATCH[2]}'"
-          else
-            echo "no match found"
-          fi
+          input="charts/orb/Chart.yaml"
+          while IFS= read -r -uN line
+          do
+            if [[ $line =~ (^\s+version: ([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)$) ]]; then
+              echo "match: '${BASH_REMATCH[2]}'"
+            fi
+            echo "$line"
+          done N< $input
+

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,10 +18,19 @@ jobs:
           while IFS= read -r line
           do
             if [[ $line =~ (^version: ([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)$) ]]; then              
-              # check if any release tag is same version
-
-              echo "ERROR - version already released: '${BASH_REMATCH[2]}'"
-              echo "Please choose a version number that never was launched"
-              exit 1
+                echo "VERSION=${BASH_REMATCH[2]}" >> $GITHUB_ENV
             fi
           done <"$file"
+
+      - uses: mukunku/tag-exists-action@v1.3.0
+        id: checkTag
+        with: 
+          tag: 'orb-${{ env.VERSION }}'
+      
+      - name: "check failed"
+        if: ${{ steps.checkTag.outputs.exists == 'true' }}
+        run: |
+              # check if any release tag is same version
+              echo "ERROR - version already released: '${BASH_REMATCH[2]}'"
+              echo "Please choose a version number that never was launched"
+              exit 1          

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -30,7 +30,6 @@ jobs:
       - name: "check failed"
         if: ${{ steps.checkTag.outputs.exists == 'true' }}
         run: |
-              # check if any release tag is same version
               echo "ERROR - version already released: '${{ env.VERSION }}'"
               echo "Please choose a version number that never was launched"
               exit 1          

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  chart-release:
+  check-release:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -14,12 +14,11 @@ jobs:
       - name: check chart release
         shell: bash
         run: |
-          input="charts/orb/Chart.yaml"
-          while IFS= read -r -uN line
+          file="charts/orb/Chart.yaml"
+          while IFS= read -r line
           do
             if [[ $line =~ (^\s+version: ([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)$) ]]; then
               echo "match: '${BASH_REMATCH[2]}'"
             fi
             echo "$line"
-          done N< $input
-
+          done <"$file"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -11,10 +11,9 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v3
 
-      - name: install chart release
+      - name: check chart release
         run: |
-          cd charts/orb/
-          str=$(<Chart.yaml)
+          str=$(cat charts/orb/Chart.yaml)
           if [[ $str =~ (^\s+version: ([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)$) ]]; then
             echo "match: '${BASH_REMATCH[2]}'"
           else

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,25 @@
+name: Chart Version Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  chart-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:       
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20.0'
+
+      - name: install chart release
+        run: |
+          cd charts/orb/
+          str=$(<Chart.yaml)
+          if [[ $str =~ (^version: ([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)$) ]]; then
+            echo "match: '${BASH_REMATCH[2]}'"
+          else
+            echo "no match found"
+          fi

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - etaques-patch-1
 
 jobs:
   chart-release:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - etaques-patch-1
 
 jobs:
   chart-release:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,0 +1,26 @@
+name: Docker build
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  chart-release:
+    name: Chart Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      - name: create deploy folder
+        run: |
+          mkdir .deploy
+      - name: create chart package
+        run: |
+          make package
+      - name: upload chart package
+        run: |
+          make upload
+      - name: indexing chart package
+        run: |
+          make index

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -28,8 +28,8 @@ jobs:
       - name: install helm
         run: |
           cd /tmp
-	        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-
+	  curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+   
       - name: checkout code
         uses: actions/checkout@v3
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -38,12 +38,12 @@ jobs:
 
       - name: create chart package
         run: |
-          make package
+          make branch=${{ github.ref_name }} package
 
       - name: upload chart package
         run: |
-          make ghtoken=${ secrets.GITHUB_TOKEN } upload
+          make branch=${{ github.ref_name }} ghtoken=${ secrets.GITHUB_TOKEN } upload
 
       - name: indexing chart package
         run: |
-          make ghtoken=${ secrets.GITHUB_TOKEN } index
+          make branch=${{ github.ref_name }} ghtoken=${ secrets.GITHUB_TOKEN } index

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -20,7 +20,6 @@ jobs:
           git clone https://github.com/helm/chart-releaser.git
           cd chart-releaser/
           go build -o cr ./cr/main.go
-          ls -lha
           sudo mv cr /usr/local/bin/
           sudo chmod a+rwx /usr/local/bin/cr
           sudo chown root.root /usr/local/bin/cr

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: upload chart package
         run: |
-          make upload
+          make ghtoken=${ secrets.GITHUB_TOKEN } upload
 
       - name: indexing chart package
         run: |

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -21,7 +21,7 @@ jobs:
           cd chart-releaser/
           go build -o cr ./cr/main.go
           mv cr /usr/local/bin/
-          chmod a+rx /usr/local/bin/cr
+          chmod a+rwx /usr/local/bin/cr
           cd ..
           rm -rf chart-releaser
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           go-version: '1.20.0'
 
-      - name: install CR and helm
+      - name: install chart release
         run: |
           git clone https://github.com/helm/chart-releaser.git
           cd chart-releaser/

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -19,13 +19,13 @@ jobs:
         run: |
           git clone https://github.com/helm/chart-releaser.git
           cd chart-releaser/
-          go build -o cr ./cr/main.go
-          sudo mv cr /usr/local/bin/
-          sudo chmod a+rwx /usr/local/bin/cr
+          go build -o cr-bin ./cr/main.go
+          sudo mv cr-bin /usr/local/bin/cr
+          sudo chmod a+rx /usr/local/bin/cr
           sudo chown root.root /usr/local/bin/cr
           cd ..
           rm -rf chart-releaser
-          /usr/local/bin/cr version
+          cr version
 
       - name: install helm
         run: cd /tmp && curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -20,8 +20,10 @@ jobs:
           git clone https://github.com/helm/chart-releaser.git
           cd chart-releaser/
           go build -o cr ./cr/main.go
-          mv cr /usr/local/bin/
-          chmod a+rwx /usr/local/bin/cr
+          ls -lha
+          sudo mv cr /sbin/
+          ls -lha /sbin/
+          sudo chmod a+rwx /sbin/cr
           cd ..
           rm -rf chart-releaser
           cr version
@@ -30,11 +32,7 @@ jobs:
         run: cd /tmp && curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
       - name: checkout code
-        uses: actions/checkout@v3
-
-      - name: debug files
-        run: |
-          ls -lha        
+        uses: actions/checkout@v3        
 
       - name: create deploy folder
         run: |

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -24,6 +24,7 @@ jobs:
           chmod a+rwx /usr/local/bin/cr
           cd ..
           rm -rf chart-releaser
+          cr version
 
       - name: install helm
         run: cd /tmp && curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -10,17 +10,40 @@ jobs:
     name: Chart Release
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v3
+    steps:       
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20.0'
+
+      - name: install CR
+        run: |
+          git clone https://github.com/helm/chart-releaser.git
+          cd chart-releaser/
+          go build -o cr ./cr/main.go
+          mv cr /usr/local/bin/
+          chmod a+x /usr/local/bin/cr
+          cd ..
+          rm -rf chart-releaser
+
+      - name: checkout code
+        uses: actions/checkout@v3
+
+      - name: debug files
+        run: |
+          ls -lha        
+
       - name: create deploy folder
         run: |
           mkdir .deploy
+
       - name: create chart package
         run: |
           make package
+
       - name: upload chart package
         run: |
           make upload
+
       - name: indexing chart package
         run: |
           make index

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v3        
 
-      - name: install helm dependencies
+      - name: install orb helm dependencies
         run: |
           make prepare-helm
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -21,7 +21,7 @@ jobs:
           cd chart-releaser/
           go build -o cr ./cr/main.go
           mv cr /usr/local/bin/
-          chmod a+x /usr/local/bin/cr
+          chmod a+rx /usr/local/bin/cr
           cd ..
           rm -rf chart-releaser
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -24,6 +24,7 @@ jobs:
           sudo mv cr /sbin/
           ls -lha /sbin/
           sudo chmod a+rwx /sbin/cr
+          sudo chown root.root /sbin/cr
           cd ..
           rm -rf chart-releaser
           cr version

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - etaques-patch-1
+
 
 jobs:
   chart-release:
@@ -33,13 +33,13 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v3        
 
-      - name: create deploy folder
-        run: |
-          mkdir .deploy
-
       - name: install helm dependencies
         run: |
           make prepare-helm
+
+      - name: create deploy folder
+        run: |
+          mkdir .deploy
 
       - name: create chart package
         run: |

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -46,4 +46,4 @@ jobs:
 
       - name: indexing chart package
         run: |
-          make index
+          make ghtoken=${ secrets.GITHUB_TOKEN } index

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -21,13 +21,12 @@ jobs:
           cd chart-releaser/
           go build -o cr ./cr/main.go
           ls -lha
-          sudo mv cr /sbin/
-          ls -lha /sbin/
-          sudo chmod a+rwx /sbin/cr
-          sudo chown root.root /sbin/cr
+          sudo mv cr /usr/local/bin/
+          sudo chmod a+rwx /usr/local/bin/cr
+          sudo chown root.root /usr/local/bin/cr
           cd ..
           rm -rf chart-releaser
-          cr version
+          /usr/local/bin/cr version
 
       - name: install helm
         run: cd /tmp && curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -26,10 +26,8 @@ jobs:
           rm -rf chart-releaser
 
       - name: install helm
-        run: |
-          cd /tmp
-	  curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-   
+        run: cd /tmp && curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+   	
       - name: checkout code
         uses: actions/checkout@v3
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,4 +1,4 @@
-name: Docker build
+name: Chart Release
 
 on:
   push:
@@ -7,7 +7,6 @@ on:
 
 jobs:
   chart-release:
-    name: Chart Release
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:       

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-
+      - etaques-patch-1
 
 jobs:
   chart-release:
@@ -47,8 +47,8 @@ jobs:
 
       - name: upload chart package
         run: |
-          sudo make branch=${{ github.ref_name }} ghtoken=${{ secrets.GITHUB_TOKEN }} upload
+          make branch=${{ github.ref_name }} ghtoken=${{ secrets.GITHUB_TOKEN }} upload
 
       - name: indexing chart package
         run: |
-          sudo make branch=${{ github.ref_name }} ghtoken=${{ secrets.GITHUB_TOKEN }} index
+          make branch=${{ github.ref_name }} ghtoken=${{ secrets.GITHUB_TOKEN }} index

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -49,8 +49,8 @@ jobs:
 
       - name: upload chart package
         run: |
-          make branch=${{ github.ref_name }} ghtoken=${{ secrets.GITHUB_TOKEN }} upload
+          sudo make branch=${{ github.ref_name }} ghtoken=${{ secrets.GITHUB_TOKEN }} upload
 
       - name: indexing chart package
         run: |
-          make branch=${{ github.ref_name }} ghtoken=${{ secrets.GITHUB_TOKEN }} index
+          sudo make branch=${{ github.ref_name }} ghtoken=${{ secrets.GITHUB_TOKEN }} index

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: install helm
         run: cd /tmp && curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-   	
+
       - name: checkout code
         uses: actions/checkout@v3
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -49,8 +49,8 @@ jobs:
 
       - name: upload chart package
         run: |
-          make branch=${{ github.ref_name }} ghtoken=${ secrets.GITHUB_TOKEN } upload
+          make branch=${{ github.ref_name }} ghtoken=${{ secrets.GITHUB_TOKEN }} upload
 
       - name: indexing chart package
         run: |
-          make branch=${{ github.ref_name }} ghtoken=${ secrets.GITHUB_TOKEN } index
+          make branch=${{ github.ref_name }} ghtoken=${{ secrets.GITHUB_TOKEN }} index

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           go-version: '1.20.0'
 
-      - name: install CR
+      - name: install CR and helm
         run: |
           git clone https://github.com/helm/chart-releaser.git
           cd chart-releaser/
@@ -24,6 +24,11 @@ jobs:
           chmod a+x /usr/local/bin/cr
           cd ..
           rm -rf chart-releaser
+
+      - name: install helm
+        run: |
+          cd /tmp
+	        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
       - name: checkout code
         uses: actions/checkout@v3
@@ -35,6 +40,10 @@ jobs:
       - name: create deploy folder
         run: |
           mkdir .deploy
+
+      - name: install helm dependencies
+        run: |
+          make prepare-helm
 
       - name: create chart package
         run: |

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ index:
 
 prepare-helm:
 	cd charts/orb && helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
-	cd charts/orb && ls -lha && rm -rf Chart.lock && helm dependency build
+	cd charts/orb && rm -rf Chart.lock && helm dependency build
 	cd ../..
 
 kind-create-all: kind-create-cluster kind-load-images kind-install-orb

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ index:
 prepare-helm:
 	cd charts/orb
 	helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
+	ls -lha
 	rm -rf Chart.lock
 	helm dependency build
 	cd ../..

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ deploy: package upload index
 
 package:
 	git checkout main
-	rm .deploy/*
+	rm -rf .deploy/*
 	helm package charts/orb -u --destination .deploy
 
 upload:

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ index:
 prepare-helm:
 	cd charts/orb
 	helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
+	cd charts/orb
 	ls -lha
 	rm -rf Chart.lock
 	helm dependency build

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+branch = main # defaults
 all:
 	echo "package, upload, index. deploy will do all."
 
@@ -5,12 +6,12 @@ deploy: package upload index
 	echo "done"
 
 package:
-	git checkout main
+	git checkout $(branch)
 	rm -rf .deploy/*
 	helm package charts/orb -u --destination .deploy
 
 upload:
-	git checkout main
+	git checkout $(branch)
 	cr upload --config cr-config.yaml --token $(ghtoken)
 
 index:

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ index:
 prepare-helm:
 	cd charts/orb
 	helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
+	rm -rf Chart.lock
 	helm dependency build
 	cd ../..
 

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,8 @@ index:
 	git checkout $(branch)
 
 prepare-helm:
-	cd charts/orb
-	helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
-	cd charts/orb
-	ls -lha
-	rm -rf Chart.lock
-	helm dependency build
+	cd charts/orb && helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
+	cd charts/orb && ls -lha && rm -rf Chart.lock && helm dependency build
 	cd ../..
 
 kind-create-all: kind-create-cluster kind-load-images kind-install-orb

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ index:
 	cr index -i ./index.yaml --config cr-config.yaml --token $(ghtoken) -c https://orb-community.github.io/orb-helm/
 	git commit -a -m "release"
 	git push
-	git checkout main
+	git checkout $(branch)
 
 prepare-helm:
 	cd charts/orb

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,11 @@ package:
 
 upload:
 	git checkout main
-	cr upload --config cr-config.yaml
+	cr upload --config cr-config.yaml --token $(ghtoken)
 
 index:
 	git checkout gh-pages
-	cr index -i ./index.yaml --config cr-config.yaml -c https://orb-community.github.io/orb-helm/
+	cr index -i ./index.yaml --config cr-config.yaml --token $(ghtoken) -c https://orb-community.github.io/orb-helm/
 	git commit -a -m "release"
 	git push
 	git checkout main

--- a/charts/orb/Chart.yaml
+++ b/charts/orb/Chart.yaml
@@ -10,7 +10,7 @@ name: orb
 description: Orb Observability Platform
 icon: https://avatars1.githubusercontent.com/u/13207490
 type: application
-version: 1.0.48
+version: 1.0.49
 appVersion: "0.26.0"
 home: https://getorb.io
 sources:


### PR DESCRIPTION
This PR is adding pipeline to publish github release and helm release automatically as soon we merge on main branch, also this validates if the helm chart version already exists in a pull request.