### PR TITLE
Update nginx-internal.yaml to add annotations variables

### DIFF
--- a/charts/orb/Chart.yaml
+++ b/charts/orb/Chart.yaml
@@ -10,7 +10,7 @@ name: orb
 description: Orb Observability Platform
 icon: https://avatars1.githubusercontent.com/u/13207490
 type: application
-version: 1.0.53
+version: 1.0.54
 appVersion: "0.27.0"
 home: https://getorb.io
 sources:

--- a/charts/orb/templates/nginx-internal.yaml
+++ b/charts/orb/templates/nginx-internal.yaml
@@ -337,6 +337,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-nginx-internal
+  annotations:
+    {{- with .Values.nginx_internal.metadata.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -347,6 +351,10 @@ spec:
       labels:
         app: {{ .Release.Name }}
         component: nginx-internal
+      annotations:
+        {{- with .Values.nginx_internal.metadata.annotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
         - image: "{{ .Values.nginx_internal.image.repository }}:{{ .Values.nginx_internal.image.tag }}"

--- a/charts/orb/values.yaml
+++ b/charts/orb/values.yaml
@@ -345,6 +345,8 @@ nginx_internal:
     pullPolicy: "IfNotPresent"
     repository: "nginx"
     tag: "1.21.1"
+  metadata:
+    annotations: {}
 
 keto:
   keto:


### PR DESCRIPTION
necessary for adding annotations so that the application stakater/reloader can be used for automatic reloadings upon TLS certification renewals.